### PR TITLE
feat(swarm):expose more swarm management calls

### DIFF
--- a/owlnest/src/net/p2p/protocols/autonat.rs
+++ b/owlnest/src/net/p2p/protocols/autonat.rs
@@ -134,15 +134,15 @@ pub mod cli {
         match command {
             AutoNat::AddServer { peer_id, address } => {
                 handle.add_server(&peer_id, address).await;
-                println!("OK.");
+                println!("AutoNat::AddServer({})-> OK.", peer_id);
             }
             AutoNat::RemoveServer { peer_id } => {
                 handle.remove_server(&peer_id).await;
-                println!("OK.");
+                println!("AutoNat::RemoveServer({})-> OK.", peer_id);
             }
             AutoNat::Probe { address } => {
                 handle.probe(&address).await;
-                println!("OK.");
+                println!("AutoNat::Probe({})-> OK.", address);
             }
             AutoNat::GetNatStatus => {
                 let (status, confidence) = handle.get_nat_status().await;

--- a/owlnest/src/net/p2p/swarm/event_handlers.rs
+++ b/owlnest/src/net/p2p/swarm/event_handlers.rs
@@ -129,6 +129,16 @@ pub fn swarm_op_exec(swarm: &mut Swarm, ev: InEvent) {
         Listen { address, callback } => {
             handle_callback_sender!(swarm.listen_on(address) => callback)
         }
+        ListListeners { callback } => {
+            let listener_list = swarm.listeners().cloned().collect();
+            handle_callback_sender!(listener_list => callback)
+        }
+        RemoveListeners {
+            listener_id,
+            callback,
+        } => {
+            handle_callback_sender!(swarm.remove_listener(listener_id)=> callback)
+        }
         AddExternalAddress { address, callback } => {
             handle_callback_sender!(swarm.add_external_address(address) => callback)
         }
@@ -142,9 +152,8 @@ pub fn swarm_op_exec(swarm: &mut Swarm, ev: InEvent) {
             let addr_list = swarm.external_addresses().cloned().collect();
             handle_callback_sender!(addr_list => callback)
         }
-        ListListeners { callback } => {
-            let listener_list = swarm.listeners().cloned().collect();
-            handle_callback_sender!(listener_list => callback)
+        ListConnected { callback } => {
+            handle_callback_sender!(swarm.connected_peers().copied().collect()=>callback)
         }
         IsConnectedToPeerId { peer_id, callback } => {
             let result = swarm.is_connected(&peer_id);

--- a/owlnest/src/net/p2p/swarm/handle.rs
+++ b/owlnest/src/net/p2p/swarm/handle.rs
@@ -22,52 +22,71 @@ impl SwarmHandle {
         /// Dial the address.
         /// Should be used in synchronous contexts.
         Dial:dial_blocking(address: <&Multiaddr>) -> Result<(), DialError>;
+
         /// Listion on the address.
         /// Should be used in synchronous contexts.
         Listen:listen_blocking(address: <&Multiaddr>) -> Result<ListenerId, TransportError<std::io::Error>>;
-        /// Manually confirm the address to be publicly reachable.
-        /// Should be used in sychronous contexts
-        AddExternalAddress:add_external_address_blocking(address: <&Multiaddr>)->();
-        /// Check if the local peer is connected to a remote peer.
-        /// Should be used in sychronous contexts
-        IsConnectedToPeerId:is_connected_blocking(peer_id: &PeerId) -> bool;
         /// List all active listeners.
-        /// Should be used in sychronous contexts
+        /// Should be used in synchronous contexts.
         ListListeners:list_listeners_blocking()->Box<[Multiaddr]>;
+        /// Remove a listener.
+        /// Should be used in synchronous contexts.
+        RemoveListeners:remove_listener_blocking(listener_id: &ListenerId)->bool;
+
+        /// Manually confirm the address to be publicly reachable.
+        /// Should be used in synchronous contexts.
+        AddExternalAddress:add_external_address_blocking(address: <&Multiaddr>)->();
         /// List all publicly reachable listen addresses.
-        /// Should be used in sychronous contexts
+        /// Should be used in synchronous contexts.
         ListExternalAddresses:list_external_addresses_blocking()->Box<[Multiaddr]>;
-        /// Disconnect from the peer.
-        /// Should be used in sychronous contexts
-        DisconnectFromPeerId:disconnect_peer_id_blocking(peer_id:&PeerId)->Result<(),()>;
         /// Remove an address from all known publicly reachable addresses.
-        /// Should be used in sychronous contexts
+        /// Should be used in synchronous contexts.
         RemoveExternalAddress:remove_external_address_blocking(address:<&Multiaddr>)->();
+
+        /// List all peers that is currently connected.
+        /// Should be used in synchronous contexts.
+        ListConnected:list_connected_blocking()->Box<[PeerId]>;
+        /// Check if the local peer is connected to a remote peer.
+        /// Should be used in synchronous contexts.
+        IsConnectedToPeerId:is_connected_blocking(peer_id: &PeerId) -> bool;
+        /// Disconnect from the peer.
+        /// Should be used in synchronous contexts.
+        DisconnectFromPeerId:disconnect_peer_id_blocking(peer_id:&PeerId)->Result<(),()>;
+
     );
     generate_handler_method!(
         /// Dial the address.
         /// Should be used in asynchronous contexts.
         Dial:dial(address: <&Multiaddr>) -> Result<(), DialError>;
+
         /// Listion on the address.
         /// Should be used in asynchronous contexts.
         Listen:listen(address: <&Multiaddr>) -> Result<ListenerId, TransportError<std::io::Error>>;
-        /// Manually confirm the address to be publicly reachable.
-        /// Should be used in asychronous contexts
-        AddExternalAddress:add_external_address(address:<&Multiaddr>)->();
         /// List all active listeners.
-        /// Should be used in asychronous contexts
+        /// Should be used in asynchronous contexts
         ListListeners:list_listeners()->Box<[Multiaddr]>;
+        /// Remove a listener.
+        /// Should be used in asynchronous contexts.
+        RemoveListeners:remove_listener(listener_id: &ListenerId)->bool;
+
+        /// Manually confirm the address to be publicly reachable.
+        /// Should be used in asynchronous contexts
+        AddExternalAddress:add_external_address(address:<&Multiaddr>)->();
         /// List all publicly reachable listen addresses.
-        /// Should be used in asychronous contexts
+        /// Should be used in asynchronous contexts
         ListExternalAddresses:list_external_addresses()->Box<[Multiaddr]>;
         /// Remove an address from all known publicly reachable addresses.
-        /// Should be used in asychronous contexts
+        /// Should be used in asynchronous contexts
         RemoveExternalAddress:remove_external_address(address:<&Multiaddr>)->();
+
+        /// List all peers that is currently connected.
+        /// Should be used in asynchronous contexts.
+        ListConnected:list_connected()->Box<[PeerId]>;
         /// Check if the local peer is connected to a remote peer.
-        /// Should be used in asychronous contexts
+        /// Should be used in asynchronous contexts
         IsConnectedToPeerId:is_connected(peer_id: &PeerId)->bool;
         /// Disconnect from the peer.
-        /// Should be used in asychronous contexts
+        /// Should be used in asynchronous contexts
         DisconnectFromPeerId:disconnect_peer_id(peer_id:&PeerId)->Result<(),()>;
     );
 }

--- a/owlnest/src/net/p2p/swarm/mod.rs
+++ b/owlnest/src/net/p2p/swarm/mod.rs
@@ -212,6 +212,13 @@ pub(crate) enum InEvent {
         address: Multiaddr,
         callback: Callback<Result<ListenerId, TransportError<std::io::Error>>>,
     },
+    ListListeners {
+        callback: Callback<Box<[Multiaddr]>>,
+    },
+    RemoveListeners {
+        listener_id: ListenerId,
+        callback: Callback<bool>,
+    },
     AddExternalAddress {
         address: Multiaddr,
         callback: Callback<()>,
@@ -220,18 +227,19 @@ pub(crate) enum InEvent {
         address: Multiaddr,
         callback: Callback<()>,
     },
-    DisconnectFromPeerId {
-        peer_id: PeerId,
-        callback: Callback<Result<(), ()>>,
-    },
+
     ListExternalAddresses {
         callback: Callback<Box<[Multiaddr]>>,
     },
-    ListListeners {
-        callback: Callback<Box<[Multiaddr]>>,
+    ListConnected {
+        callback: Callback<Box<[PeerId]>>,
     },
     IsConnectedToPeerId {
         peer_id: PeerId,
         callback: Callback<bool>,
+    },
+    DisconnectFromPeerId {
+        peer_id: PeerId,
+        callback: Callback<Result<(), ()>>,
     },
 }


### PR DESCRIPTION
- expose `remove_listener`.
  - unfortunately due to limitation on `libp2p`, it is not possible to remove a listener using cli

- expose `list_connected` 